### PR TITLE
move render ui animations into a component

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,31 +1,17 @@
 import React from 'react';
 
 import uiAnimations from './ui-animations.js';
-import renderHTML from 'react-render-html';
+import UiAnimationsList from './components/UiAnimationsList.js';
+
 
 function App() {
-
-  let items = uiAnimations.map(function (item) {
-    console.log(item);
-    return (
-      <div class="codepen-container">
-        <h3>
-          {item.title}
-        </h3>
-        <p>
-          {item.description}
-        </p>
-        { renderHTML(item.codepen) }
-      </div>)
-  })
-
   return (
     <div className="container">
       <h1>
         css wizard
       </h1>
-      <div class="codepens">
-        {items}
+      <div className="codepens">
+        <UiAnimationsList uiAnimationsData={uiAnimations} />
       </div>
     </div>
   );

--- a/src/components/UiAnimationsList.js
+++ b/src/components/UiAnimationsList.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import renderHTML from 'react-render-html';
+
+function uiAnimationList (props) {
+
+  const { uiAnimationsData } = props;
+
+  let items = uiAnimationsData.map(function (item) {
+    return (
+      <div
+        key={item.id} 
+        className="codepen-container">
+        <h3>
+          {item.title}
+        </h3>
+        <p>
+          {item.description}
+        </p>
+        {renderHTML(item.codepen)}
+      </div>)
+  });
+
+  return items
+}
+
+export default uiAnimationList;

--- a/src/ui-animations.js
+++ b/src/ui-animations.js
@@ -4,6 +4,7 @@
 
 const uiAnimations = [
   {
+    id: 0,
     title: 'increasing width',
     description: 'the width of a div increases over time',
     codepen: `<p class="codepen" data-height="265" data-theme-id="dark" data-default-tab="result" data-user="brianmunoz" data-slug-hash="gOajBdY" style="height: 265px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="increasing width over time">


### PR DESCRIPTION
closes #9 

update

* move code that renders all the ui animations into a component
* import the newly created component with the ui-animations as a prop

add
* id to every item in the ui-animations array 